### PR TITLE
Option to add external D3D9 directory

### DIFF
--- a/lr2_chainload/d3d9.cpp
+++ b/lr2_chainload/d3d9.cpp
@@ -3,7 +3,7 @@
 #include <windows.h>
 #include <filesystem>
 
-std::filesystem::path d3d9path;
+static std::filesystem::path d3d9path;
 
 struct d3d9_dll {
 	HMODULE dll;
@@ -58,7 +58,7 @@ void LoadExternalD3D9(HMODULE hModule) {
 		{
 			// Find the external d3d9 directory
 			if (line.starts_with(L"d3d9_overwrite=")) {
-				d3d9path = line.substr(wcslen(L"d3d9_overwrite="));
+				d3d9path = line.substr(std::wstring_view(L"d3d9_overwrite=").length());
 				break;
 			}
 		}
@@ -100,7 +100,7 @@ BOOL APIENTRY DllMain(HMODULE hModule, DWORD ul_reason_for_call, LPVOID lpReserv
 			d3d9.dll = LoadLibrary(std::filesystem::path(system_dir).append("d3d9.dll").c_str());
 		}
 		else {
-			d3d9.dll = LoadLibrary(std::filesystem::path(d3d9path).append("d3d9.dll").c_str());
+			d3d9.dll = LoadLibrary(d3d9path.append("d3d9.dll").c_str());
 		}
 
 		if (d3d9.dll == 0)

--- a/lr2_chainload/d3d9.cpp
+++ b/lr2_chainload/d3d9.cpp
@@ -54,17 +54,12 @@ void LoadExternalD3D9(HMODULE hModule) {
 
 	if (library_list.is_open())
 	{
-		// Read filenames from each line and call LoadLibrary.
 		for (std::wstring line; std::getline(library_list, line);)
 		{
-			// Treat lines starting with '#' as comments.
-			if (line.empty() || line.starts_with(L"#"))
-				continue;
-
-			// Too lazy to make the code clean, it works for now
+			// Find the external d3d9 directory
 			if (line.starts_with(L"d3d9_overwrite=")) {
 				d3d9path = line.substr(wcslen(L"d3d9_overwrite="));
-				continue;
+				break;
 			}
 		}
 	}

--- a/lr2_chainload/d3d9.cpp
+++ b/lr2_chainload/d3d9.cpp
@@ -79,7 +79,7 @@ void LoadDlls(HMODULE hModule) {
 		for (std::wstring line; std::getline(library_list, line);)
 		{
 			// Treat lines starting with '#' as comments.
-			if (line.empty() || line.starts_with(L"#"))
+			if (line.empty() || line.starts_with(L"#") || line.starts_with(L"d3d9_overwrite="))
 				continue;
 
 			LoadLibrary(line.c_str());


### PR DESCRIPTION
Could be useful in cases if you are running LR2 with some DirectX wrapper, like dgVoodoo.
When releasing, consider adding these lines to chainload.txt, please.
```#
# If you need to use external D3D9.dll,
# you can do this by inserting a line like this:
#
# d3d9_overwrite=<path to external d3d9 dll directory>
#
# Useful, if you are running LR2 through some DirectX wrappers, like dgVoodoo.
# Before writing path to a library, make sure that the dll is 32-bit